### PR TITLE
[BROK-2523] Fix rate limiter odd number bug

### DIFF
--- a/lib/ex_limiter/base.ex
+++ b/lib/ex_limiter/base.ex
@@ -62,9 +62,11 @@ defmodule ExLimiter.Base do
 
     %Bucket{value: val} = leak(storage, bucket)
 
-    mult = scale / limit
+    mult = Integer.floor_div(scale, limit)
 
-    round(max((scale - val) / mult, 0))
+    (scale - val)
+    |> Integer.floor_div(mult)
+    |> max(0)
   end
 
   defp leak(storage, bucket) do


### PR DESCRIPTION
A problem existed in the rate limiter calculation when a the last number attempts remaining is `1`. The time delta calculation always returned `>= 0.5` which then the rounding logic would round back to 1 when it real result should have been `0`, thus rating limiting the user.

The fix is to always round down, so that values between `0.5` and `0.9` will not cause a rounding up error. This using the `Integer.floor_div/2` function instead of the standard lib `/` because the latter will always return a float.
